### PR TITLE
chore: java-docker-build-tutorial to 1.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: java-docker-build-tutorial
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.0
+  version: 1.0.1


### PR DESCRIPTION
chore: Promote java-docker-build-tutorial to version 1.0.1